### PR TITLE
Add test timer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,14 @@ module stronglytyped
 go 1.20
 
 require (
+	github.com/charmbracelet/bubbles v0.16.1
+	github.com/charmbracelet/bubbletea v0.24.2
+	github.com/charmbracelet/lipgloss v0.9.1
+	github.com/urfave/cli/v2 v2.25.7
+)
+
+require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbletea v0.24.2 // indirect
-	github.com/charmbracelet/lipgloss v0.9.1 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v0.16.1 h1:6uzpAAaT9ZqKssntbvZMlksWHruQLNxg49H5WdeuYSY=
+github.com/charmbracelet/bubbles v0.16.1/go.mod h1:2QCp9LFlEsBQMvIYERr7Ww2H2bA7xen1idUDIzm/+Xc=
 github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06RaW2cx/SY=
 github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
 github.com/charmbracelet/lipgloss v0.9.1 h1:PNyd3jvaJbg4jRHKWXnCj1akQm4rh8dbEzN1p/u1KWg=

--- a/src/styles.go
+++ b/src/styles.go
@@ -8,4 +8,5 @@ var (
 	OvertypedTextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#ba2222"))
 	UnreachedTextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#808080"))
 	CursorTextStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#f5e614"))
+	TimeRemainingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#e2b714"))
 )


### PR DESCRIPTION
Closes #9.

## Usage notes
- The time remaining is updated every second and displayed above the test text in the view.
- The `--length` flag now works to specify the test duration.
- When the timer expires or the user finishes entering the final word, user input no longer modifies the test state and a dummy statistics view is displayed. You can press `ctrl+c` to quit.

## Implementation notes
- This feature uses https://github.com/charmbracelet/bubbletea/tree/master/examples/timer
- In addition to the timer object, a new `isDone` field is added to the `model` struct. When the timer expires or the user finishes typing all the words, `isDone` is set to `true`. Both `Update` and `View` now dispatch to separate methods called `DoneUpdate` and `DoneView`, respectively, when `isDone` is `true`. If we wanted more global states, we could replace `isDone` with a proper state field and have additional specialized `Update` and `View` functions (or just switch on state inside `Update` and `View`).
